### PR TITLE
Support for servers and base path in OAS 3

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -3,6 +3,7 @@
 const get = require('lodash.get');
 const Ajv = require('ajv');
 const SwaggerParser = require('swagger-parser');
+const URL = require('url');
 
 const { defaultFormatsValidators } = require('./validators/formatValidators.js');
 const schemaPreprocessor = require('./utils/schema-preprocessor');
@@ -40,7 +41,7 @@ function buildValidations(referenced, dereferenced, receivedOptions) {
     const schemas = {};
 
     const basePaths = dereferenced.servers
-        ? dereferenced.servers.map(({ url }) => new URL(url).pathname)
+        ? dereferenced.servers.map(({ url }) => URL.parse(url).pathname)
         : [dereferenced.basePath || '/'];
 
     Object.keys(dereferenced.paths).forEach(function (currentPath) {

--- a/test/openapi2/general/options-test.js
+++ b/test/openapi2/general/options-test.js
@@ -59,6 +59,14 @@ describe('oai2 - general tests', () => {
                 expect(typeof receivedSchema['/pets']['post'].parameters).to.exist;
             });
         });
+        describe('base path', () => {
+            it('is prepended to each path', () => {
+                const swaggerPath = path.join(__dirname, 'pet-store-basepath.yaml');
+                const schema = schemaValidatorGenerator.buildSchemaSync(swaggerPath, {});
+                expect(Object.keys(schema)).to.eql(['/staging/pets']);
+                expect(typeof schema['/staging/pets'].post.body.validate).to.eql('function');
+            });
+        });
     });
 
     describe('async', () => {

--- a/test/openapi2/general/pet-store-basepath.yaml
+++ b/test/openapi2/general/pet-store-basepath.yaml
@@ -1,0 +1,25 @@
+swagger: "2.0"
+info:
+  version: 1.0.0
+  title: Swagger Petstore
+  license:
+    name: MIT
+basePath: /staging
+paths:
+  /pets:
+    post:
+      summary: Create a pet
+      operationId: createPets
+      parameters:
+        - name: body
+          in: body
+          required: true
+          schema:
+            required:
+              - name
+            properties:
+              name:
+                type: string
+      responses:
+        "201":
+          description: Null response

--- a/test/openapi3/general/general-oai3-test.js
+++ b/test/openapi3/general/general-oai3-test.js
@@ -103,6 +103,22 @@ describe('oai3 - general tests', () => {
                 expect(typeof receivedSchema['/json'].put.responses['200'].validate).to.eql('function');
             });
         });
+        describe('servers', () => {
+            it('copies schema for each base path', () => {
+                const swaggerPath = path.join(__dirname, 'pets-general.yaml');
+                const schema = schemaValidatorGenerator.buildSchemaSync(swaggerPath, {});
+                expect(Object.keys(schema)).to.eql([
+                    '/text',
+                    '/staging/text',
+                    '/empty',
+                    '/staging/empty',
+                    '/json',
+                    '/staging/json'
+                ]);
+                expect(typeof schema['/json'].put.body['application/json'].validate).to.eql('function');
+                expect(typeof schema['/staging/json'].put.body['application/json'].validate).to.eql('function');
+            });
+        });
     });
 
     describe('async', () => {

--- a/test/openapi3/general/pets-general.yaml
+++ b/test/openapi3/general/pets-general.yaml
@@ -79,6 +79,7 @@ paths:
                 $ref: "#/components/schemas/Error"
 servers:
 - url: http://petstore.swagger.io
+- url: http://petstore.swagger.io/staging/
 components:
   schemas:
     Error:


### PR DESCRIPTION
Adds the validation schemas at every `server.url` which fixes https://github.com/PayU/openapi-validator-middleware/issues/105