### PR TITLE
Support empty servers in OpenAPI 3.0 spec

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -40,7 +40,7 @@ function buildValidations(referenced, dereferenced, receivedOptions) {
 
     const schemas = {};
 
-    const basePaths = dereferenced.servers
+    const basePaths = dereferenced.servers && dereferenced.servers.length
         ? dereferenced.servers.map(({ url }) => new URL(url).pathname)
         : [dereferenced.basePath || '/'];
 

--- a/test/openapi3/general/general-oai3-test.js
+++ b/test/openapi3/general/general-oai3-test.js
@@ -118,7 +118,6 @@ describe('oai3 - general tests', () => {
                 expect(typeof schema['/json'].put.body['application/json'].validate).to.eql('function');
                 expect(typeof schema['/staging/json'].put.body['application/json'].validate).to.eql('function');
             });
-
             it('correctly works with empty servers', () => {
                 const swaggerPath = path.join(__dirname, 'pets-general-empty-servers.yaml');
                 const schema = schemaValidatorGenerator.buildSchemaSync(swaggerPath, {});

--- a/test/openapi3/general/general-oai3-test.js
+++ b/test/openapi3/general/general-oai3-test.js
@@ -118,6 +118,27 @@ describe('oai3 - general tests', () => {
                 expect(typeof schema['/json'].put.body['application/json'].validate).to.eql('function');
                 expect(typeof schema['/staging/json'].put.body['application/json'].validate).to.eql('function');
             });
+
+            it('correctly works with empty servers', () => {
+                const swaggerPath = path.join(__dirname, 'pets-general-empty-servers.yaml');
+                const schema = schemaValidatorGenerator.buildSchemaSync(swaggerPath, {});
+                expect(Object.keys(schema)).to.eql([
+                    '/text',
+                    '/empty',
+                    '/json'
+                ]);
+                expect(typeof schema['/json'].put.body['application/json'].validate).to.eql('function');
+            });
+            it('correctly works without servers', () => {
+                const swaggerPath = path.join(__dirname, 'pets-general-no-servers.yaml');
+                const schema = schemaValidatorGenerator.buildSchemaSync(swaggerPath, {});
+                expect(Object.keys(schema)).to.eql([
+                    '/text',
+                    '/empty',
+                    '/json'
+                ]);
+                expect(typeof schema['/json'].put.body['application/json'].validate).to.eql('function');
+            });
         });
     });
 

--- a/test/openapi3/general/pets-general-empty-servers.yaml
+++ b/test/openapi3/general/pets-general-empty-servers.yaml
@@ -1,0 +1,95 @@
+openapi: 3.0.0
+info:
+  version: 1.0.0
+  title: Swagger Petstore
+  license:
+    name: MIT
+paths:
+  /text:
+    put:
+      requestBody:
+        content:
+          plain/text:
+            schema:
+              type: string
+        required: true
+      responses:
+        "200":
+          description: Expected response to a valid request
+          content:
+            plain/text:
+              schema:
+                properties:
+                  lastname:
+                    type: string
+        default:
+          description: unexpected error
+          content:
+            text/plain:
+              schema:
+                $ref: "#/components/schemas/Error"
+
+  /empty:
+    post:
+      requestBody:
+        description: Expected response to a valid request
+        content:
+          plain/text:
+            schema:
+              type: string
+        required: true
+      responses:
+        "200":
+          description: Expected response to a valid request
+          content:
+            plain/text:
+              schema:
+                properties:
+                  lastname:
+                    type: string
+        default:
+          description: unexpected error
+          content:
+            text/plain:
+              schema:
+                $ref: "#/components/schemas/Error"
+  /json:
+    put:
+      parameters:
+        - in: header
+          name: public-key
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: string
+        required: true
+      responses:
+        "200":
+          description: Expected response to a valid request
+          content:
+            application/json:
+              schema:
+                properties:
+                  lastname:
+                    type: string
+        default:
+          description: unexpected error
+          content:
+            text/plain:
+              schema:
+                $ref: "#/components/schemas/Error"
+servers: []
+components:
+  schemas:
+    Error:
+      required:
+      - code
+      - message
+      properties:
+        code:
+          type: integer
+        message:
+          type: string

--- a/test/openapi3/general/pets-general-no-servers.yaml
+++ b/test/openapi3/general/pets-general-no-servers.yaml
@@ -1,0 +1,94 @@
+openapi: 3.0.0
+info:
+  version: 1.0.0
+  title: Swagger Petstore
+  license:
+    name: MIT
+paths:
+  /text:
+    put:
+      requestBody:
+        content:
+          plain/text:
+            schema:
+              type: string
+        required: true
+      responses:
+        "200":
+          description: Expected response to a valid request
+          content:
+            plain/text:
+              schema:
+                properties:
+                  lastname:
+                    type: string
+        default:
+          description: unexpected error
+          content:
+            text/plain:
+              schema:
+                $ref: "#/components/schemas/Error"
+
+  /empty:
+    post:
+      requestBody:
+        description: Expected response to a valid request
+        content:
+          plain/text:
+            schema:
+              type: string
+        required: true
+      responses:
+        "200":
+          description: Expected response to a valid request
+          content:
+            plain/text:
+              schema:
+                properties:
+                  lastname:
+                    type: string
+        default:
+          description: unexpected error
+          content:
+            text/plain:
+              schema:
+                $ref: "#/components/schemas/Error"
+  /json:
+    put:
+      parameters:
+        - in: header
+          name: public-key
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: string
+        required: true
+      responses:
+        "200":
+          description: Expected response to a valid request
+          content:
+            application/json:
+              schema:
+                properties:
+                  lastname:
+                    type: string
+        default:
+          description: unexpected error
+          content:
+            text/plain:
+              schema:
+                $ref: "#/components/schemas/Error"
+components:
+  schemas:
+    Error:
+      required:
+      - code
+      - message
+      properties:
+        code:
+          type: integer
+        message:
+          type: string


### PR DESCRIPTION
#46 broke support for empty array as `servers`.