### PR TITLE
Fix for parsing relative server URLs

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -37,7 +37,8 @@ function buildValidations(referenced, dereferenced, receivedOptions) {
     const schemas = {};
 
     const basePaths = dereferenced.servers && dereferenced.servers.length
-        ? dereferenced.servers.map(({ url }) => new URL(url).pathname)
+        // dummy base path is required by URL constructor when server url is not absolute
+        ? dereferenced.servers.map(({ url }) => new URL(url, 'http://example.com').pathname)
         : [dereferenced.basePath || '/'];
 
     Object.keys(dereferenced.paths).forEach(currentPath => {

--- a/test/openapi3/general/pets-general.yaml
+++ b/test/openapi3/general/pets-general.yaml
@@ -83,7 +83,7 @@ paths:
                 $ref: "#/components/schemas/Error"
 servers:
 - url: http://petstore.swagger.io
-- url: http://petstore.swagger.io/staging/
+- url: /staging/
 components:
   schemas:
     Error:


### PR DESCRIPTION
If the server URL is relative like `/some-path` then the `URL` constructor throws an error because it doesn't know how to resolve it. Passing a dummy base URL to the constructor avoids the problem.