### PR TITLE
Don't skip parameter validation when parameter array is empty.

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -122,10 +122,8 @@ function buildRequestValidator(referenced, dereferenced, currentPath, currentMet
         localParameters = oai2.buildPathParameters(parameters, pathParameters);
     }
 
-    if (localParameters.length > 0 || options.contentTypeValidation) {
-        requestSchema.parameters = buildParametersValidation(localParameters,
-            dereferenced.paths[currentPath][currentMethod].consumes || dereferenced.paths[currentPath].consumes || dereferenced.consumes, options);
-    }
+    requestSchema.parameters = buildParametersValidation(localParameters,
+        dereferenced.paths[currentPath][currentMethod].consumes || dereferenced.paths[currentPath].consumes || dereferenced.consumes, options);
 
     return requestSchema;
 }

--- a/src/utils/ajv-utils.js
+++ b/src/utils/ajv-utils.js
@@ -3,11 +3,9 @@ const filesKeyword = require('../customKeywords/files'),
     contentKeyword = require('../customKeywords/contentTypeValidation');
 
 function addCustomKeyword(ajv, formats, keywords) {
-    if (formats) {
-        formats.forEach(function (format) {
-            ajv.addFormat(format.name, format.pattern);
-        });
-    }
+    formats.forEach(function (format) {
+        ajv.addFormat(format.name, format.pattern);
+    });
 
     if (keywords) {
         keywords.forEach((keyword) => {

--- a/test/openapi3/general/general-oai3-test.js
+++ b/test/openapi3/general/general-oai3-test.js
@@ -252,7 +252,7 @@ describe('oai3 - general tests', () => {
     describe('init with json schema', () => {
         function loadYamlAsJson(filename) {
             const swaggerPath = path.join(__dirname, filename);
-            const jsonSchema = yaml.load(fs.readFileSync(swaggerPath), 'utf8');
+            const jsonSchema = yaml.load(fs.readFileSync(swaggerPath, 'utf8'));
             return jsonSchema;
         }
         describe('loading yaml with discriminator with allOf', () => {

--- a/test/openapi3/request/pets-request.yaml
+++ b/test/openapi3/request/pets-request.yaml
@@ -109,6 +109,21 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/error_model'
+  /pets-empty-query:
+    get:
+      summary: get all pets with no query allowed
+      security:
+      - public-key: []
+      description: >-
+      tags:
+      - pets
+      responses:
+        '200':
+          description: list of pets
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/pets'
   /pets/{pet_id}:
     get:
       summary: get pet by id


### PR DESCRIPTION
Parameter validation is ignored in the case when no parameters are specified. This is due to a bug here: https://github.com/PayU/api-schema-builder/blob/5dff1ea544fa0b59a03b5aaec00cacd596b3325d/src/index.js#L125

```js
if (localParameters.length > 0 || options.contentTypeValidation) {
        requestSchema.parameters = buildParametersValidation(localParameters,
            dereferenced.paths[currentPath][currentMethod].consumes || dereferenced.paths[currentPath].consumes || dereferenced.consumes, options);
    }
```

Which incorrectly skips parameter building in case when there are no parameters and content type validation is not `true`. However parameters have nothing to do with content type, so this should always be done. Since content type validation is again checked there's no reason to do this check in this place: https://github.com/PayU/api-schema-builder/blob/5dff1ea544fa0b59a03b5aaec00cacd596b3325d/src/index.js#L238:

```js
    ajvParametersSchema.properties.headers.content = createContentTypeHeaders(options.contentTypeValidation, contentTypes);

module.exports = function createContentTypeHeaders(validate, contentTypes) {
    if (!validate || !contentTypes) return;

    return {
        types: contentTypes
    };
};
```