### PR TITLE
Added fix for basic relative URLs and support variables in servers URLs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,12 @@
 # Master
 
+# 2.0.6 - 10 Mar, 2021
+### Improvements
+- Added support for relative URLs and variables in servers #59
+
 # 2.0.5 - 08 Mar, 2021
 ### Improvements
 - Update dependencies to fix security vulnerabilities
-- Added support for relative URLs and variables in servers #59
 
 # 2.0.4 - 26 Nov, 2020
 ### Improvements

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Master
 
-# 2.0.6 - 10 Mar, 2021
+# 2.0.6 - 27 Mar, 2021
 ### Improvements
 - Added support for relative URLs and variables in servers #59
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Master
 
+# 2.0.5 - 4 March, 2021
+### Improvements
+- Added support for relative URLs and variables in servers #59
+
 # 2.0.4 - 26 Nov, 2020
 ### Improvements
 - Nullable is now fully supported

--- a/src/index.js
+++ b/src/index.js
@@ -37,7 +37,7 @@ function buildValidations(referenced, dereferenced, receivedOptions) {
     const schemas = {};
 
     const basePaths = dereferenced.servers && dereferenced.servers.length
-        ? dereferenced.servers.map(({ url }) => url.slice(0, 1) === "/" ? url : new URL(url).pathname)
+        ? dereferenced.servers.map(({ url }) => url.slice(0, 1) === '/' ? url : new URL(url).pathname)
         : [dereferenced.basePath || '/'];
 
     Object.keys(dereferenced.paths).forEach(currentPath => {

--- a/src/index.js
+++ b/src/index.js
@@ -37,7 +37,12 @@ function buildValidations(referenced, dereferenced, receivedOptions) {
     const schemas = {};
 
     const basePaths = dereferenced.servers && dereferenced.servers.length
-        ? dereferenced.servers.map(({ url }) => url.slice(0, 1) === '/' ? url : new URL(url).pathname)
+        ? dereferenced.servers.map(({ url, variables = {} }) => {
+            Object.keys(variables).forEach((key) => {
+                url = url.replace(new RegExp(`{${key}}`), variables[key].default || '')
+            })
+            return url.slice(0,1) === '/' ? url : new URL(url).pathname
+        })
         : [dereferenced.basePath || '/'];
 
     Object.keys(dereferenced.paths).forEach(currentPath => {

--- a/src/index.js
+++ b/src/index.js
@@ -37,7 +37,7 @@ function buildValidations(referenced, dereferenced, receivedOptions) {
     const schemas = {};
 
     const basePaths = dereferenced.servers && dereferenced.servers.length
-        ? dereferenced.servers.map(({ url }) => new URL(url).pathname)
+        ? dereferenced.servers.map(({ url }) => url.slice(0, 1) === "/" ? url : new URL(url).pathname)
         : [dereferenced.basePath || '/'];
 
     Object.keys(dereferenced.paths).forEach(currentPath => {

--- a/src/index.js
+++ b/src/index.js
@@ -31,19 +31,29 @@ function buildSchemaSync(pathOrSchema, options) {
     return buildValidations(jsonSchema, dereferencedSchema, options);
 }
 
+function getBasePaths(dereferenced) {
+    return dereferenced.servers && dereferenced.servers.length
+    ? dereferenced.servers.map(({ url, variables = {} }) => {
+        // replace variables with deafault values
+        Object.keys(variables).forEach((key) => {
+            url = url.replace(new RegExp(`{${key}}`), variables[key].default);
+        });
+
+        // replace leading '//' with 'http://' (in cases such as //api.example.com)
+        url = url.replace(/^\/\//, 'http://');
+
+        // return base path
+        return (/\/\//.test(url)) ? new URL(url).pathname : url;
+    })
+    : [dereferenced.basePath || '/'];
+}
+
 function buildValidations(referenced, dereferenced, receivedOptions) {
     const options = getOptions(receivedOptions);
 
     const schemas = {};
 
-    const basePaths = dereferenced.servers && dereferenced.servers.length
-        ? dereferenced.servers.map(({ url, variables = {} }) => {
-            Object.keys(variables).forEach((key) => {
-                url = url.replace(new RegExp(`{${key}}`), variables[key].default || '');
-            });
-            return url.slice(0, 1) === '/' ? url : new URL(url).pathname;
-        })
-        : [dereferenced.basePath || '/'];
+    const basePaths = getBasePaths(dereferenced);
 
     Object.keys(dereferenced.paths).forEach(currentPath => {
         const operationSchemas = {};

--- a/src/index.js
+++ b/src/index.js
@@ -33,19 +33,19 @@ function buildSchemaSync(pathOrSchema, options) {
 
 function getBasePaths(dereferenced) {
     return dereferenced.servers && dereferenced.servers.length
-    ? dereferenced.servers.map(({ url, variables = {} }) => {
+        ? dereferenced.servers.map(({ url, variables = {} }) => {
         // replace variables with deafault values
-        Object.keys(variables).forEach((key) => {
-            url = url.replace(new RegExp(`{${key}}`), variables[key].default);
-        });
+            Object.keys(variables).forEach((key) => {
+                url = url.replace(new RegExp(`{${key}}`), variables[key].default);
+            });
 
-        // replace leading '//' with 'http://' (in cases such as //api.example.com)
-        url = url.replace(/^\/\//, 'http://');
+            // replace leading '//' with 'http://' (in cases such as //api.example.com)
+            url = url.replace(/^\/\//, 'http://');
 
-        // return base path
-        return (/\/\//.test(url)) ? new URL(url).pathname : url;
-    })
-    : [dereferenced.basePath || '/'];
+            // return base path
+            return (/\/\//.test(url)) ? new URL(url).pathname : url;
+        })
+        : [dereferenced.basePath || '/'];
 }
 
 function buildValidations(referenced, dereferenced, receivedOptions) {

--- a/src/index.js
+++ b/src/index.js
@@ -39,9 +39,9 @@ function buildValidations(referenced, dereferenced, receivedOptions) {
     const basePaths = dereferenced.servers && dereferenced.servers.length
         ? dereferenced.servers.map(({ url, variables = {} }) => {
             Object.keys(variables).forEach((key) => {
-                url = url.replace(new RegExp(`{${key}}`), variables[key].default || '')
-            })
-            return url.slice(0,1) === '/' ? url : new URL(url).pathname
+                url = url.replace(new RegExp(`{${key}}`), variables[key].default || '');
+            });
+            return url.slice(0, 1) === '/' ? url : new URL(url).pathname;
         })
         : [dereferenced.basePath || '/'];
 

--- a/test/openapi3/general/pets-general.yaml
+++ b/test/openapi3/general/pets-general.yaml
@@ -96,7 +96,8 @@ servers:
       enum:
         - staging
         - ''
-      default: ''
+      default: staging
+- url: //petstore.swagger.io
 components:
   schemas:
     Error:

--- a/test/openapi3/general/pets-general.yaml
+++ b/test/openapi3/general/pets-general.yaml
@@ -84,6 +84,7 @@ paths:
 servers:
 - url: http://petstore.swagger.io
 - url: http://petstore.swagger.io/staging/
+- url: /staging
 components:
   schemas:
     Error:

--- a/test/openapi3/general/pets-general.yaml
+++ b/test/openapi3/general/pets-general.yaml
@@ -85,6 +85,18 @@ servers:
 - url: http://petstore.swagger.io
 - url: http://petstore.swagger.io/staging/
 - url: /staging
+- url: '{protocol}://petstore.swagger.io/{env}'
+  variables:
+    protocol:
+      enum:
+        - http
+        - https
+      default: http
+    env:
+      enum:
+        - staging
+        - ''
+      default: ''
 components:
   schemas:
     Error:


### PR DESCRIPTION
I don't want to put a specific url of server in OpenAPI file, as it can be used in different environments, so I use the following:

```yaml
openapi: '3.0.2'
servers:
  - url: /api
```
 
On init method I get the error:
```
TypeError [ERR_INVALID_URL]: Invalid URL: /api
    at onParseError (internal/url.js:257:9)
    at new URL (internal/url.js:333:5)
```
