### PR TITLE
fix content type validation for OAS3

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ If the element is an object, it must include `name` and `definition`. If the ele
 - `makeOptionalAttributesNullable` - Boolean that forces preprocessing of Swagger schema to include 'null' as possible type for all non-required properties. Main use-case for this is to ensure correct handling of null values when Ajv type coercion is enabled
 - `ajvConfigBody` - Object that will be passed as config to new Ajv instance which will be used for validating request body. Can be useful to e. g. enable type coercion (to automatically convert strings to numbers etc). See Ajv documentation for supported values.
 - `ajvConfigParams` - Object that will be passed as config to new Ajv instance which will be used for validating request headers and parameters. See Ajv documentation for supported values.
-- `contentTypeValidation` - Boolean that indicates if to perform content type validation in case `consume` field is specified and the request body is not empty.
+- `contentTypeValidation` - Boolean that indicates if to perform content type validation in case `consumes` (OAS2) or `content` (OAS3) field is specified and the request body is not empty.
 - `expectFormFieldsInBody` - Boolean that indicates whether form fields of non-file type that are specified in the schema should be validated against request body (e. g. Multer is copying text form fields to body)
 - `buildRequests` - Boolean that indicates whether if create validators for requests, default is true.
 - `buildResponses` - Boolean that indicates whether if create validators for responses, default is false.

--- a/src/index.js
+++ b/src/index.js
@@ -123,8 +123,10 @@ function buildRequestValidator(referenced, dereferenced, currentPath, currentMet
     }
 
     if (localParameters.length > 0 || options.contentTypeValidation) {
-        requestSchema.parameters = buildParametersValidation(localParameters,
-            dereferenced.paths[currentPath][currentMethod].consumes || dereferenced.paths[currentPath].consumes || dereferenced.consumes, options);
+        const contentTypes = isOpenApi3 ?
+            Object.keys( get(dereferenced.paths[currentPath][currentMethod], 'requestBody.content') || {} ) :
+            ( dereferenced.paths[currentPath][currentMethod].consumes || dereferenced.paths[currentPath].consumes || dereferenced.consumes );
+        requestSchema.parameters = buildParametersValidation(localParameters, contentTypes, options);
     }
 
     return requestSchema;


### PR DESCRIPTION
the contentTypeValidation option is currently broken for OAS3 schemas, this PR fixes it